### PR TITLE
Fixed last update time showing incorrectly

### DIFF
--- a/src/components/graph.jsx
+++ b/src/components/graph.jsx
@@ -336,15 +336,7 @@ class Graph extends Component {
     }
 
     if (isLoaded) {
-      const lastUpdatedTime = timeSince(
-        new Date(
-          [
-            grandTotal[0].lastupdatedtime.split(/\//)[1],
-            grandTotal[0].lastupdatedtime.split(/\//)[0],
-            grandTotal[0].lastupdatedtime.split(/\//)[2],
-          ].join("/")
-        ).getTime()
-      );
+      const lastUpdatedTime = timeSince(grandTotal[0].lastupdatedtime, "DD/MM/YYYY");
       return (
         <React.Fragment>
           <div className={graphClass}>

--- a/src/components/notifications.jsx
+++ b/src/components/notifications.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import LaunchRoundedIcon from "@material-ui/icons/LaunchRounded";
 import FiberManualRecordIcon from "@material-ui/icons/FiberManualRecord";
+import moment from "moment";
 
 import { Link } from "react-router-dom";
 
@@ -36,42 +37,8 @@ class Updates extends Component {
       return datum / 1000;
     }
 
-    function timeSince(timeStamp) {
-      var now = new Date(),
-        secondsPast = (now.getTime() - timeStamp) / 1000;
-
-      if (secondsPast < 60) {
-        return (
-          parseInt(secondsPast) +
-          ` second${parseInt(secondsPast) > 1 ? "s" : ""} ago`
-        );
-      }
-
-      if (secondsPast < 3600) {
-        return (
-          parseInt(secondsPast / 60) +
-          ` minute${parseInt(secondsPast / 60) > 1 ? "s" : ""} ago`
-        );
-      }
-
-      if (secondsPast <= 86400) {
-        return (
-          parseInt(secondsPast / 3600) +
-          ` hour${parseInt(secondsPast / 3600) > 1 ? "s" : ""} ago `
-        );
-      }
-      if (secondsPast > 86400) {
-        let day = timeStamp.getDate();
-        var month = timeStamp
-          .toDateString()
-          .match(/ [a-zA-Z]*/)[0]
-          .replace(" ", "");
-        var year =
-          timeStamp.getFullYear() === now.getFullYear()
-            ? ""
-            : " " + timeStamp.getFullYear();
-        return day + " " + month + year;
-      }
+    function timeSince(timeStamp, dateFormat) {
+      return moment(timeStamp, dateFormat).fromNow();
     }
 
     let totalDeltaConfirmed = 0;
@@ -116,15 +83,7 @@ class Updates extends Component {
                     >
                       <h6 style={{ fontSize: 10, color: "grey" }}>
                         {"about " +
-                          timeSince(
-                            new Date(
-                              [
-                                item.lastupdatedtime.split(/\//)[1],
-                                item.lastupdatedtime.split(/\//)[0],
-                                item.lastupdatedtime.split(/\//)[2],
-                              ].join("/")
-                            ).getTime()
-                          ) +
+                          timeSince(item.lastupdatedtime, "DD/MM/YYYY") +
                           "  "}
                         <span style={{ verticalAlign: "0.09rem", fontSize: 7 }}>
                           <FiberManualRecordIcon

--- a/src/components/updates.jsx
+++ b/src/components/updates.jsx
@@ -209,15 +209,7 @@ class Updates extends Component {
                       >
                         <h6 style={{ fontSize: 10, color: "grey" }}>
                           {"about " +
-                            timeSince(
-                              new Date(
-                                [
-                                  item.lastupdatedtime.split(/\//)[1],
-                                  item.lastupdatedtime.split(/\//)[0],
-                                  item.lastupdatedtime.split(/\//)[2],
-                                ].join("/")
-                              ).getTime()
-                            ) +
+                            timeSince(item.lastupdatedtime, "DD/MM/YYYY") +
                             "  "}
                           <span
                             style={{ verticalAlign: "0.09rem", fontSize: 7 }}

--- a/src/utils/common-functions.js
+++ b/src/utils/common-functions.js
@@ -1,3 +1,4 @@
+import moment from "moment";
 const months = {
   "01": "Jan",
   "02": "Feb",
@@ -91,40 +92,6 @@ export function toTimestamp(strDate) {
   return datum / 1000;
 }
 
-export function timeSince(timeStamp) {
-  var now = new Date(),
-    secondsPast = (now.getTime() - timeStamp) / 1000;
-
-  if (secondsPast < 60) {
-    return (
-      parseInt(secondsPast) +
-      ` second${parseInt(secondsPast) > 1 ? "s" : ""} ago`
-    );
-  }
-
-  if (secondsPast < 3600) {
-    return (
-      parseInt(secondsPast / 60) +
-      ` minute${parseInt(secondsPast / 60) > 1 ? "s" : ""} ago`
-    );
-  }
-
-  if (secondsPast <= 86400) {
-    return (
-      parseInt(secondsPast / 3600) +
-      ` hour${parseInt(secondsPast / 3600) > 1 ? "s" : ""} ago `
-    );
-  }
-  if (secondsPast > 86400) {
-    let day = timeStamp.getDate();
-    var month = timeStamp
-      .toDateString()
-      .match(/ [a-zA-Z]*/)[0]
-      .replace(" ", "");
-    var year =
-      timeStamp.getFullYear() === now.getFullYear()
-        ? ""
-        : " " + timeStamp.getFullYear();
-    return day + " " + month + year;
-  }
+export function timeSince(timeStamp, dateFormat) {
+  return moment(timeStamp, dateFormat).fromNow();
 }


### PR DESCRIPTION
Fixed at following locations:

- Notification
- Map
- Updates

Simplified the relative time calculation method using moment.
![lastUpdatetime](https://user-images.githubusercontent.com/7390719/84774555-e7cba800-afd5-11ea-8f46-32aeacd9f11d.png)
